### PR TITLE
Allow dynamic loading of items in cogs folder

### DIFF
--- a/cookiedough.py
+++ b/cookiedough.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from discord.ext import commands
+from os import walk
 
 logging.basicConfig(level=logging.INFO, format='[%(asctime)s][%(name)s][%(levelname)s] %(message)s',
                     datefmt='%Y-%m-%d_%H:%M:%S')
@@ -8,12 +9,17 @@ logging.basicConfig(level=logging.INFO, format='[%(asctime)s][%(name)s][%(leveln
 description = '''A cookie loving Discord bot'''
 bot = commands.Bot(command_prefix='.', description=description, case_insensitive=True)
 
-bot.load_extension("cogs.admin")
-bot.load_extension("cogs.fun")
-bot.load_extension("cogs.main")
-bot.load_extension("cogs.misc")
-bot.load_extension("cogs.pinboard")
-bot.load_extension("cogs.stickers")
-# bot.load_extension("cogs.testing")
+cogpath = "cogs"
+testmode = False
+
+filenames = next(walk(cogpath+"/"), (None, None, []))[2] # Walk the cogs directory
+for _,v in enumerate(filenames):  #Enumerate directory for iter
+  v = v[:-3]
+  if v == "testing" and not testmode: continue;
+  try:
+    bot.load_extension(cogpath+"."+str(v))
+  except:
+    print("Error in cog "+str(v)+". Could not load extension.")
+    pass
 
 bot.run(sys.argv[1])


### PR DESCRIPTION
Use a path walk instead of static, repetetive and drawn-out calls to bot.load_extension

Essentially decouples the cog files from depending on being defined explicitly in cookiedough.py