### PR TITLE
Add Webhook token checks

### DIFF
--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -92,7 +92,7 @@ they can!')
 
         wh_info_found = None
         for wh_info in await message.guild.webhooks():
-            if wh_info.channel.name == destination_name:
+            if wh_info.channel.name == destination_name and wh_info.token is not None:
                 wh_info_found = wh_info
                 break
         if wh_info_found is None:

--- a/cogs/pinboard.py
+++ b/cogs/pinboard.py
@@ -48,7 +48,7 @@ class AutoMod(commands.Cog):
             return
         wh_info_found = None
         for wh_info in await message.guild.webhooks():
-            if wh_info.channel.name == pinboard_name:
+            if wh_info.channel.name == pinboard_name and wh_info.token is not None:
                 wh_info_found = wh_info
                 break
         if wh_info_found is None:

--- a/cogs/stickers.py
+++ b/cogs/stickers.py
@@ -156,7 +156,7 @@ class Stickers(commands.Cog):
             channel_name = ctx.channel.name
             wh_info_found = None
             for wh_info in await ctx.guild.webhooks():
-                if wh_info.channel.name == channel_name:
+                if wh_info.channel.name == channel_name and wh_info.token is not None:
                     wh_info_found = wh_info
                     break
             if wh_info_found is None:


### PR DESCRIPTION
Discord have updated their webhooks to allow for a new type that doesn't support messages. I've added a check to ensure that Cookie Dough only looks for valid webhooks, and will error our if none is found.